### PR TITLE
Implement initial One-Tap modules and playback

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -1,0 +1,33 @@
+# Implementation Notes
+
+This document records the initial implementation work for the One‑Tap TV Launcher
+MVP as described in the repository `README`.
+
+## Summary
+
+- Added fully fledged Python module under `script.module.one_tap` providing
+  configuration loading/saving, JSON‑RPC utilities, logging helpers, playback
+  history storage and episode selection logic.
+- Implemented playback controller `plugin.one_tap.play` which loads the
+  caregiver configuration, chooses the next episode in **Order** or **Random**
+  mode and instructs Kodi to start playback via JSON‑RPC.
+- Filled in `addon.xml` manifests for all add‑ons so they can be packaged by the
+  `packaging/build_addons.py` script.
+- Added minimal stubs for the randomizer background service and caregiver menu
+  to allow future feature expansion.
+
+## Design Choices
+
+- **File based storage:** Playback history uses a small JSON file instead of a
+  database for simplicity during early development.
+- **Kodi fallbacks:** Modules gracefully degrade when run outside Kodi by
+  avoiding hard dependencies on `xbmc`/`xbmcvfs` modules, easing desktop testing.
+- **Explicit logging:** A tiny wrapper normalises logging both inside Kodi and
+  during development, keeping messages consistent across environments.
+
+## Next Steps
+
+- Flesh out caregiver UI and PIN handling.
+- Extend randomiser service to support comfort weighting and exclude‑last logic
+  without relying solely on the playback controller.
+- Replace JSON file storage with a more robust database if needed.

--- a/addons/plugin.one_tap.play/addon.xml
+++ b/addons/plugin.one_tap.play/addon.xml
@@ -1,0 +1,12 @@
+<addon id="plugin.one_tap.play" name="One-Tap Play" version="0.1.0" provider-name="One-Tap">
+    <requires>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.one_tap" version="0.1.0"/>
+    </requires>
+    <extension point="xbmc.python.script" library="default.py"/>
+    <extension point="xbmc.addon.metadata">
+        <summary>One-Tap playback controller</summary>
+        <description>Selects and starts the next episode immediately.</description>
+        <platform>all</platform>
+    </extension>
+</addon>

--- a/addons/plugin.one_tap.play/default.py
+++ b/addons/plugin.one_tap.play/default.py
@@ -1,0 +1,72 @@
+"""Entry point for the One-Tap playback controller.
+
+The script expects ``show_id`` to be provided as a query parameter.  The
+configured tile for the show is looked up and the next episode is selected
+according to the global configuration.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import urllib.parse
+from typing import Dict, List
+
+from one_tap import config, jsonrpc, selection
+from one_tap.logging import get_logger
+
+try:  # pragma: no cover - depends on Kodi
+    import xbmcvfs  # type: ignore
+except ImportError:  # pragma: no cover - desktop/dev
+    xbmcvfs = None  # type: ignore
+
+logger = get_logger("plugin.one_tap.play")
+
+
+def _list_episodes(path: str) -> List[str]:
+    """Return a sorted list of episode files within ``path``."""
+
+    exts = {".mkv", ".mp4", ".avi"}
+    if xbmcvfs:
+        dirs, files = xbmcvfs.listdir(path)
+        episodes = [os.path.join(path, f) for f in files if os.path.splitext(f)[1].lower() in exts]
+    else:
+        episodes = [os.path.join(path, f) for f in os.listdir(path) if os.path.splitext(f)[1].lower() in exts]
+    episodes.sort()
+    return episodes
+
+
+def _get_params() -> Dict[str, str]:
+    if len(sys.argv) < 3:
+        return {}
+    qs = sys.argv[2][1:]
+    return {k: v[0] for k, v in urllib.parse.parse_qs(qs).items()}
+
+
+def main() -> None:
+    params = _get_params()
+    show_id = params.get("show_id")
+    if not show_id:
+        logger.error("show_id parameter required")
+        return
+
+    cfg = config.load_config()
+    tile = next((t for t in cfg.get("tiles", []) if t.get("show_id") == show_id), None)
+    if not tile:
+        logger.error("show_id %s not found in config", show_id)
+        return
+
+    episodes = _list_episodes(tile["path"])
+    if not episodes:
+        logger.error("No episodes found for %s", tile["path"])
+        return
+
+    episode = selection.choose_episode(show_id, episodes, cfg.get("mode", "order"), cfg.get("random", {}))
+    logger.info("Playing %s", episode)
+    try:
+        jsonrpc.play_file(episode)
+    except Exception as exc:  # pragma: no cover - runtime
+        logger.error(f"Failed to start playback: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/script.module.one_tap/addon.xml
+++ b/addons/script.module.one_tap/addon.xml
@@ -1,0 +1,10 @@
+<addon id="script.module.one_tap" name="One-Tap Module" version="0.1.0" provider-name="One-Tap">
+    <requires>
+        <import addon="xbmc.python" version="3.0.0"/>
+    </requires>
+    <extension point="xbmc.python.module"/>
+    <extension point="xbmc.addon.metadata">
+        <summary>Shared utilities for One-Tap add-ons</summary>
+        <platform>all</platform>
+    </extension>
+</addon>

--- a/addons/script.module.one_tap/lib/one_tap/config.py
+++ b/addons/script.module.one_tap/lib/one_tap/config.py
@@ -1,0 +1,62 @@
+"""Configuration loading and saving for One-Tap TV Launcher.
+
+This module reads the caregiver configuration JSON which defines the
+available tiles, playback mode, and other settings. It falls back to a
+reasonable default configuration if the file does not yet exist so that
+the add-ons can operate during early development.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # Kodi runtime
+    import xbmc  # type: ignore
+    import xbmcvfs  # type: ignore
+except ImportError:  # Desktop/dev fallback
+    xbmc = None  # type: ignore
+    xbmcvfs = None  # type: ignore
+
+# Default location for the caregiver configuration file.  Kodi's
+# ``special://`` paths are translated to an absolute filesystem path when
+# running inside Kodi.  During development we resolve the path relative to
+# the current working directory which mirrors the runtime layout.
+CONFIG_PATH = "special://profile/addon_data/plugin.one_tap.play/config.json"
+
+
+def _resolve(path: str) -> Path:
+    """Resolve ``special://`` paths both inside and outside Kodi.
+
+    When executed inside Kodi the ``xbmcvfs`` module knows how to translate
+    ``special://`` URIs.  In a normal Python environment we simply treat the
+    string as a regular file system path.
+    """
+
+    if xbmcvfs:  # pragma: no branch - runtime check
+        return Path(xbmcvfs.translatePath(path))
+    return Path(path).expanduser().resolve()
+
+
+def load_config() -> Dict[str, Any]:
+    """Return the caregiver configuration as a dictionary.
+
+    If the configuration file does not exist a minimal default structure is
+    returned.  Callers can modify the structure and persist it with
+    :func:`save_config`.
+    """
+
+    path = _resolve(CONFIG_PATH)
+    if not path.exists():
+        return {"tiles": [], "mode": "order", "random": {}, "ui": {}, "pin": ""}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    """Persist configuration ``cfg`` to :data:`CONFIG_PATH`."""
+
+    path = _resolve(CONFIG_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2, sort_keys=True)

--- a/addons/script.module.one_tap/lib/one_tap/db.py
+++ b/addons/script.module.one_tap/lib/one_tap/db.py
@@ -1,0 +1,47 @@
+"""Simple JSON based progress database for One-Tap TV Launcher."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from . import config
+
+# Path inside the add-on's profile directory where playback history is stored
+PROGRESS_PATH = "special://profile/addon_data/plugin.one_tap.play/progress.json"
+
+
+def _path() -> Path:
+    return config._resolve(PROGRESS_PATH)
+
+
+def _load() -> Dict[str, List[str]]:
+    path = _path()
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def _save(data: Dict[str, List[str]]) -> None:
+    path = _path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def get_history(show_id: str) -> List[str]:
+    """Return playback history list for ``show_id``."""
+
+    return _load().get(show_id, [])
+
+
+def update_history(show_id: str, episode: str, max_history: int = 50) -> None:
+    """Append ``episode`` to the history for ``show_id`` keeping ``max_history`` entries."""
+
+    data = _load()
+    history = data.get(show_id, [])
+    history.append(episode)
+    history = history[-max_history:]
+    data[show_id] = history
+    _save(data)

--- a/addons/script.module.one_tap/lib/one_tap/jsonrpc.py
+++ b/addons/script.module.one_tap/lib/one_tap/jsonrpc.py
@@ -1,0 +1,36 @@
+"""Minimal JSON-RPC helper for communicating with Kodi."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - depends on Kodi
+    import xbmc  # type: ignore
+except ImportError:  # pragma: no cover - desktop/dev
+    xbmc = None  # type: ignore
+
+
+class KodiNotAvailable(RuntimeError):
+    """Raised when JSON-RPC is invoked outside the Kodi environment."""
+
+
+def call(method: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Invoke a JSON-RPC ``method`` with optional ``params``."""
+
+    if not xbmc:
+        raise KodiNotAvailable("xbmc module not available")
+
+    request = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params:
+        request["params"] = params
+    response = xbmc.executeJSONRPC(json.dumps(request))
+    try:
+        return json.loads(response) if response else {}
+    except Exception:  # pragma: no cover - defensive
+        return {}
+
+
+def play_file(path: str) -> Dict[str, Any]:
+    """Open ``path`` in Kodi's active player."""
+
+    return call("Player.Open", {"item": {"file": path}})

--- a/addons/script.module.one_tap/lib/one_tap/logging.py
+++ b/addons/script.module.one_tap/lib/one_tap/logging.py
@@ -1,0 +1,42 @@
+"""Logging helper usable both inside and outside Kodi."""
+from __future__ import annotations
+
+import logging
+try:  # pragma: no cover - depends on Kodi
+    import xbmc  # type: ignore
+except ImportError:  # pragma: no cover - desktop/dev
+    xbmc = None  # type: ignore
+
+
+class Logger:
+    """Small wrapper that mimics :mod:`logging` and ``xbmc.log``."""
+
+    def __init__(self, name: str = "one_tap") -> None:
+        self.name = name
+        if xbmc:
+            self._use_kodi = True
+        else:
+            self._use_kodi = False
+            self._logger = logging.getLogger(name)
+
+    def _log(self, level: int, msg: str) -> None:
+        if self._use_kodi:
+            xbmc.log(f"[{self.name}] {msg}", level)
+        else:
+            self._logger.log(level, msg)
+
+    def info(self, msg: str) -> None:
+        self._log(logging.INFO, msg)
+
+    def warning(self, msg: str) -> None:
+        self._log(logging.WARNING, msg)
+
+    def error(self, msg: str) -> None:
+        self._log(logging.ERROR, msg)
+
+    def debug(self, msg: str) -> None:
+        self._log(logging.DEBUG, msg)
+
+
+def get_logger(name: str = "one_tap") -> Logger:
+    return Logger(name)

--- a/addons/script.module.one_tap/lib/one_tap/selection.py
+++ b/addons/script.module.one_tap/lib/one_tap/selection.py
@@ -1,0 +1,47 @@
+"""Episode selection logic for One-Tap TV Launcher."""
+from __future__ import annotations
+
+import random
+from typing import Iterable, List
+
+from . import db
+
+
+def choose_episode(
+    show_id: str,
+    episodes: Iterable[str],
+    mode: str = "order",
+    random_cfg: dict | None = None,
+) -> str:
+    """Return the next episode path according to ``mode``.
+
+    ``episodes`` should be an iterable of episode file paths sorted in the
+    desired order.  ``mode`` can be ``"order"`` or ``"random"``.  For random
+    mode the configuration in ``random_cfg`` is consulted which currently
+    supports ``exclude_last_n``.
+    """
+
+    eps: List[str] = list(episodes)
+    if not eps:
+        raise ValueError("No episodes available")
+
+    history = db.get_history(show_id)
+    if mode == "random":
+        random_cfg = random_cfg or {}
+        exclude_n = int(random_cfg.get("exclude_last_n", 0))
+        candidates = [e for e in eps if e not in history[-exclude_n:]]
+        if not candidates:
+            candidates = eps
+        episode = random.choice(candidates)
+    else:  # order
+        last = history[-1] if history else None
+        if last in eps:
+            idx = eps.index(last) + 1
+        else:
+            idx = 0
+        if idx >= len(eps):
+            idx = 0
+        episode = eps[idx]
+
+    db.update_history(show_id, episode)
+    return episode

--- a/addons/script.one_tap.caregiver/addon.xml
+++ b/addons/script.one_tap.caregiver/addon.xml
@@ -1,0 +1,12 @@
+<addon id="script.one_tap.caregiver" name="One-Tap Caregiver" version="0.1.0" provider-name="One-Tap">
+    <requires>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.one_tap" version="0.1.0"/>
+    </requires>
+    <extension point="xbmc.python.script" library="default.py"/>
+    <extension point="xbmc.addon.metadata">
+        <summary>Caregiver menu</summary>
+        <description>Manage tiles, playback mode and PIN protection.</description>
+        <platform>all</platform>
+    </extension>
+</addon>

--- a/addons/script.one_tap.caregiver/default.py
+++ b/addons/script.one_tap.caregiver/default.py
@@ -1,0 +1,14 @@
+"""Placeholder caregiver script."""
+from __future__ import annotations
+
+from one_tap.logging import get_logger
+
+logger = get_logger("script.one_tap.caregiver")
+
+
+def main() -> None:
+    logger.info("Caregiver menu not yet implemented")
+
+
+if __name__ == "__main__":
+    main()

--- a/addons/service.one_tap.random/addon.xml
+++ b/addons/service.one_tap.random/addon.xml
@@ -1,0 +1,12 @@
+<addon id="service.one_tap.random" name="One-Tap Randomizer" version="0.1.0" provider-name="One-Tap">
+    <requires>
+        <import addon="xbmc.python" version="3.0.0"/>
+        <import addon="script.module.one_tap" version="0.1.0"/>
+    </requires>
+    <extension point="xbmc.service" library="service.py" start="startup"/>
+    <extension point="xbmc.addon.metadata">
+        <summary>Randomizer background service</summary>
+        <description>Maintains playback history and randomization state.</description>
+        <platform>all</platform>
+    </extension>
+</addon>

--- a/addons/service.one_tap.random/service.py
+++ b/addons/service.one_tap.random/service.py
@@ -1,0 +1,25 @@
+"""Background service stub for the One-Tap randomizer."""
+from __future__ import annotations
+
+from one_tap.logging import get_logger
+
+logger = get_logger("service.one_tap.random")
+
+try:  # pragma: no cover - depends on Kodi
+    import xbmc  # type: ignore
+except ImportError:  # pragma: no cover - desktop/dev
+    xbmc = None  # type: ignore
+
+
+def run() -> None:
+    logger.info("Randomizer service starting")
+    if xbmc:
+        monitor = xbmc.Monitor()
+        while not monitor.abortRequested():
+            if monitor.waitForAbort(60):
+                break
+    logger.info("Randomizer service stopped")
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add working module utilities (config, json-rpc, logging, selection, history)
- implement playback controller for order/random episode selection
- define addon manifests and add stubs for randomizer service and caregiver script

## Testing
- `python -m py_compile addons/script.module.one_tap/lib/one_tap/config.py addons/script.module.one_tap/lib/one_tap/db.py addons/script.module.one_tap/lib/one_tap/jsonrpc.py addons/script.module.one_tap/lib/one_tap/logging.py addons/script.module.one_tap/lib/one_tap/selection.py addons/plugin.one_tap.play/default.py addons/service.one_tap.random/service.py addons/script.one_tap.caregiver/default.py`


------
https://chatgpt.com/codex/tasks/task_e_68be44d5ba008323855a869152976440