### PR TITLE
feat: add random preselection service

### DIFF
--- a/addons/script.module.one_tap/lib/one_tap/random_state.py
+++ b/addons/script.module.one_tap/lib/one_tap/random_state.py
@@ -1,0 +1,52 @@
+"""Shared storage for pre-selected random episodes."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from . import config
+
+# Location for pre-selected episode candidates
+PRESELECT_PATH = "special://profile/addon_data/service.one_tap.random/preselected.json"
+
+
+def _path() -> Path:
+    return config._resolve(PRESELECT_PATH)
+
+
+def load() -> Dict[str, List[str]]:
+    path = _path()
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save(data: Dict[str, List[str]]) -> None:
+    path = _path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def get(show_id: str) -> List[str]:
+    return load().get(show_id, [])
+
+
+def set(show_id: str, candidates: List[str]) -> None:
+    data = load()
+    data[show_id] = candidates
+    save(data)
+
+
+def consume_first(show_id: str) -> None:
+    data = load()
+    items = data.get(show_id)
+    if items:
+        items = items[1:]
+        if items:
+            data[show_id] = items
+        else:
+            data.pop(show_id, None)
+        save(data)

--- a/addons/script.module.one_tap/lib/one_tap/selection.py
+++ b/addons/script.module.one_tap/lib/one_tap/selection.py
@@ -16,8 +16,8 @@ def episode_candidates(
 
     ``episodes`` should be an iterable of episode file paths sorted in the
     desired order. ``mode`` can be ``"order"`` or ``"random"``. For random
-    mode the configuration in ``random_cfg`` is consulted which currently
-    supports ``exclude_last_n``.
+    mode the configuration in ``random_cfg`` supports ``exclude_last_n`` and
+    ``use_comfort_weights``.
 
     History is **not** updated here; the caller is responsible for recording
     the successfully played episode."""
@@ -30,10 +30,23 @@ def episode_candidates(
     if mode == "random":
         random_cfg = random_cfg or {}
         exclude_n = int(random_cfg.get("exclude_last_n", 0))
+        use_weights = bool(random_cfg.get("use_comfort_weights"))
         recent = set(history[-exclude_n:])
         candidates = [e for e in eps if e not in recent]
         if not candidates:
-            candidates = eps
+            candidates = eps.copy()
+        if use_weights and len(candidates) > 1:
+            last = history[-1] if history else None
+            last_idx = eps.index(last) if last in eps else 0
+            weights = []
+            for e in candidates:
+                idx = eps.index(e)
+                distance = abs(idx - last_idx)
+                weights.append(1 / (1 + distance))
+            first = random.choices(candidates, weights=weights, k=1)[0]
+            remaining = [e for e in candidates if e != first]
+            random.shuffle(remaining)
+            return [first] + remaining
         random.shuffle(candidates)
         return candidates
 

--- a/addons/service.one_tap.random/service.py
+++ b/addons/service.one_tap.random/service.py
@@ -1,23 +1,70 @@
-"""Background service stub for the One-Tap randomizer."""
+"""Background service for the One-Tap randomizer."""
 from __future__ import annotations
 
-from one_tap.logging import get_logger
+import os
+from typing import Dict, List
 
-logger = get_logger("service.one_tap.random")
+from one_tap import config, jsonrpc, random_state, selection
+from one_tap.logging import get_logger
 
 try:  # pragma: no cover - depends on Kodi
     import xbmc  # type: ignore
+    import xbmcvfs  # type: ignore
 except ImportError:  # pragma: no cover - desktop/dev
     xbmc = None  # type: ignore
+    xbmcvfs = None  # type: ignore
+
+logger = get_logger("service.one_tap.random")
+
+
+def _list_episodes(path: str) -> List[str]:
+    """Return a sorted list of episode files within ``path``."""
+
+    exts = {".mkv", ".mp4", ".avi"}
+    if xbmcvfs:
+        dirs, files = xbmcvfs.listdir(path)
+        episodes = [os.path.join(path, f) for f in files if os.path.splitext(f)[1].lower() in exts]
+    else:
+        episodes = [os.path.join(path, f) for f in os.listdir(path) if os.path.splitext(f)[1].lower() in exts]
+    episodes.sort()
+    return episodes
+
+
+def _update() -> None:
+    cfg = config.load_config()
+    if cfg.get("mode") != "random":
+        return
+    random_cfg = cfg.get("random", {})
+    data: Dict[str, List[str]] = {}
+    for tile in cfg.get("tiles", []):
+        show_id = tile.get("show_id")
+        path = tile.get("path")
+        if not show_id or not path:
+            continue
+        episodes = _list_episodes(path)
+        if not episodes:
+            continue
+        candidates = selection.episode_candidates(show_id, episodes, "random", random_cfg)
+        data[show_id] = candidates
+    if data:
+        random_state.save(data)
+        try:  # Best effort notification
+            jsonrpc.call(
+                "JSONRPC.NotifyAll", {"sender": "service.one_tap.random", "message": "updated"}
+            )
+        except Exception:  # pragma: no cover - environment dependent
+            logger.debug("JSON-RPC notification failed")
 
 
 def run() -> None:
     logger.info("Randomizer service starting")
+    _update()
     if xbmc:
         monitor = xbmc.Monitor()
         while not monitor.abortRequested():
-            if monitor.waitForAbort(60):
+            if monitor.waitForAbort(300):
                 break
+            _update()
     logger.info("Randomizer service stopped")
 
 


### PR DESCRIPTION
## Summary
- implement comfort-weighted random selection with exclusion of recent episodes
- add background service to preselect episodes and notify Kodi
- share preselected candidates with playback controller

## Testing
- `python -m py_compile addons/script.module.one_tap/lib/one_tap/random_state.py addons/script.module.one_tap/lib/one_tap/selection.py addons/service.one_tap.random/service.py addons/plugin.one_tap.play/default.py`

------
https://chatgpt.com/codex/tasks/task_e_68be6c5e25ec832382eea5c21cae64eb