### PR TITLE
Add minimal tile-only skin

### DIFF
--- a/skin.tile_only/addon.xml
+++ b/skin.tile_only/addon.xml
@@ -1,0 +1,16 @@
+<addon id="skin.tile_only" name="One-Tap Tile Only" version="0.1.0" provider-name="One-Tap">
+    <requires>
+        <import addon="xbmc.gui" version="5.16.0"/>
+        <import addon="script.module.one_tap" version="0.1.0"/>
+        <import addon="plugin.one_tap.play" version="0.1.0"/>
+    </requires>
+    <extension point="xbmc.gui.skin" defaultresolution="1080i" effectstoggle="true">
+        <res width="1920" height="1080" aspect="16:9" default="true" />
+    </extension>
+    <extension point="xbmc.service" library="service.py" start="startup"/>
+    <extension point="xbmc.addon.metadata">
+        <summary>One-Tap tile-only home screen</summary>
+        <description>Minimal skin that shows configured tiles for one-tap playback.</description>
+        <platform>all</platform>
+    </extension>
+</addon>

--- a/skin.tile_only/service.py
+++ b/skin.tile_only/service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Startup service for the tile-only skin.
+
+Loads the caregiver configuration and exposes tile metadata as window
+properties for the Home screen.  This allows the skin's XML to remain
+simple and only display the configured tiles.
+"""
+
+from typing import Any, Dict
+
+try:  # Kodi runtime
+    import xbmc  # type: ignore
+    import xbmcgui  # type: ignore
+except ImportError:  # pragma: no cover - outside Kodi
+    xbmc = None  # type: ignore
+    xbmcgui = None  # type: ignore
+
+from one_tap import config
+
+MAX_TILES = 12
+
+
+def main() -> None:
+    """Populate Window(Home) properties for each configured tile."""
+    if xbmcgui is None:
+        # Running outside Kodi; nothing to do
+        return
+
+    cfg: Dict[str, Any] = config.load_config()
+    tiles = cfg.get("tiles", [])
+    window = xbmcgui.Window(10000)  # Home window
+
+    for i in range(1, MAX_TILES + 1):
+        window.clearProperty(f"tile.{i}.label")
+        window.clearProperty(f"tile.{i}.show_id")
+
+    for idx, tile in enumerate(tiles[:MAX_TILES], start=1):
+        window.setProperty(f"tile.{idx}.label", tile.get("label", ""))
+        window.setProperty(f"tile.{idx}.show_id", tile.get("show_id", ""))
+
+    window.setProperty("tile.count", str(len(tiles)))
+    if xbmc:
+        xbmc.log("One-Tap skin properties initialized", xbmc.LOGINFO)
+
+
+if __name__ == "__main__":
+    main()

--- a/skin.tile_only/xml/Home.xml
+++ b/skin.tile_only/xml/Home.xml
@@ -1,0 +1,97 @@
+<window>
+    <defaultcontrol always="true">2001</defaultcontrol>
+    <controls>
+        <grouplist id="9000">
+            <left>360</left>
+            <top>180</top>
+            <width>1200</width>
+            <height>720</height>
+            <itemgap>20</itemgap>
+            <orientation>vertical</orientation>
+            <control type="button" id="2001">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.1.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.1.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.1.show_id)])</onclick>
+            </control>
+            <control type="button" id="2002">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.2.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.2.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.2.show_id)])</onclick>
+            </control>
+            <control type="button" id="2003">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.3.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.3.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.3.show_id)])</onclick>
+            </control>
+            <control type="button" id="2004">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.4.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.4.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.4.show_id)])</onclick>
+            </control>
+            <control type="button" id="2005">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.5.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.5.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.5.show_id)])</onclick>
+            </control>
+            <control type="button" id="2006">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.6.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.6.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.6.show_id)])</onclick>
+            </control>
+            <control type="button" id="2007">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.7.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.7.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.7.show_id)])</onclick>
+            </control>
+            <control type="button" id="2008">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.8.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.8.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.8.show_id)])</onclick>
+            </control>
+            <control type="button" id="2009">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.9.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.9.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.9.show_id)])</onclick>
+            </control>
+            <control type="button" id="2010">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.10.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.10.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.10.show_id)])</onclick>
+            </control>
+            <control type="button" id="2011">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.11.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.11.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.11.show_id)])</onclick>
+            </control>
+            <control type="button" id="2012">
+                <width>1200</width>
+                <height>120</height>
+                <label>$INFO[Window(Home).Property(tile.12.label)]</label>
+                <visible>!String.IsEmpty(Window(Home).Property(tile.12.label))</visible>
+                <onclick>RunScript(plugin.one_tap.play,show_id=$INFO[Window(Home).Property(tile.12.show_id)])</onclick>
+            </control>
+        </grouplist>
+    </controls>
+</window>


### PR DESCRIPTION
## Summary
- add addon.xml defining tile-only skin and startup service
- render Home window as a vertical list of configured tiles
- load caregiver configuration at startup to expose tile labels and ids

## Testing
- `python -m py_compile skin.tile_only/service.py addons/plugin.one_tap.play/default.py`
- `python packaging/build_addons.py`


------
https://chatgpt.com/codex/tasks/task_e_68be6c6282948323aa3725cde6c2fa04