### PR TITLE
refactor: replace JSON history with SQLite database

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -22,8 +22,8 @@ MVP as described in the repository `README`.
 
 ## Design Choices
 
-- **File based storage:** Playback history uses a small JSON file instead of a
-  database for simplicity during early development.
+- **SQLite storage:** Playback history uses a lightweight SQLite database for
+  durability while remaining simple to manage.
 - **Kodi fallbacks:** Modules gracefully degrade when run outside Kodi by
   avoiding hard dependencies on `xbmc`/`xbmcvfs` modules, easing desktop testing.
 - **Explicit logging:** A tiny wrapper normalises logging both inside Kodi and
@@ -35,4 +35,3 @@ MVP as described in the repository `README`.
 - Extend randomiser service to support comfort weighting and exclude‑last logic
   without relying solely on the playback controller.
 - Implement auto-advance and smarter error handling based on player events.
-- Replace JSON file storage with a more robust database if needed.

--- a/addons/script.module.one_tap/lib/one_tap/db.py
+++ b/addons/script.module.one_tap/lib/one_tap/db.py
@@ -1,47 +1,67 @@
-"""Simple JSON based progress database for One-Tap TV Launcher."""
+"""Playback history storage using SQLite for One-Tap TV Launcher."""
 from __future__ import annotations
 
-import json
+import sqlite3
 from pathlib import Path
-from typing import Dict, List
+from typing import List
 
 from . import config
 
 # Path inside the add-on's profile directory where playback history is stored
-PROGRESS_PATH = "special://profile/addon_data/plugin.one_tap.play/progress.json"
+DB_PATH = "special://profile/addon_data/plugin.one_tap.play/one_tap.db"
+DEFAULT_MAX_HISTORY = 50
 
 
 def _path() -> Path:
-    return config._resolve(PROGRESS_PATH)
+    return config._resolve(DB_PATH)
 
 
-def _load() -> Dict[str, List[str]]:
-    path = _path()
-    if path.exists():
-        with path.open("r", encoding="utf-8") as f:
-            return json.load(f)
-    return {}
-
-
-def _save(data: Dict[str, List[str]]) -> None:
+def _connect() -> sqlite3.Connection:
     path = _path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS history (
+            show_id TEXT NOT NULL,
+            episode TEXT NOT NULL,
+            played_at REAL DEFAULT (strftime('%s','now'))
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_history_show ON history(show_id)")
+    return conn
 
 
 def get_history(show_id: str) -> List[str]:
     """Return playback history list for ``show_id``."""
 
-    return _load().get(show_id, [])
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT episode FROM history WHERE show_id=? ORDER BY rowid",
+            (show_id,),
+        ).fetchall()
+    return [r[0] for r in rows]
 
 
-def update_history(show_id: str, episode: str, max_history: int = 50) -> None:
+def update_history(
+    show_id: str, episode: str, max_history: int = DEFAULT_MAX_HISTORY
+) -> None:
     """Append ``episode`` to the history for ``show_id`` keeping ``max_history`` entries."""
 
-    data = _load()
-    history = data.get(show_id, [])
-    history.append(episode)
-    history = history[-max_history:]
-    data[show_id] = history
-    _save(data)
+    with _connect() as conn:
+        conn.execute(
+            "INSERT INTO history(show_id, episode) VALUES (?, ?)",
+            (show_id, episode),
+        )
+        conn.execute(
+            """
+            DELETE FROM history
+            WHERE show_id=?
+              AND rowid NOT IN (
+                SELECT rowid FROM history WHERE show_id=? ORDER BY rowid DESC LIMIT ?
+              )
+            """,
+            (show_id, show_id, max_history),
+        )
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,44 @@
+import json
+import sys
+from pathlib import Path
+
+# Ensure one_tap package is importable
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root / "addons" / "script.module.one_tap" / "lib"))
+
+from one_tap import config, db
+
+
+def _fake_resolve(base: Path, path: str) -> Path:
+    """Resolve paths within tests to the temporary directory."""
+    return base / Path(path).name
+
+
+def test_update_history_limits_records(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "_resolve", lambda p: _fake_resolve(tmp_path, p))
+    monkeypatch.setattr(db, "DB_PATH", "history.db")
+
+    for i in range(60):
+        db.update_history("show", f"ep{i}", max_history=50)
+
+    history = db.get_history("show")
+    assert len(history) == 50
+    assert history[0] == "ep10"
+    assert history[-1] == "ep59"
+
+
+def test_migrate_history(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "_resolve", lambda p: _fake_resolve(tmp_path, p))
+    monkeypatch.setattr(db, "DB_PATH", "history.db")
+
+    legacy = {"show": ["a", "b", "c"]}
+    (tmp_path / "progress.json").write_text(json.dumps(legacy))
+
+    sys.path.append(str(repo_root))
+    from tools import migrate_history
+
+    monkeypatch.setattr(migrate_history, "OLD_JSON_PATH", "progress.json")
+
+    migrate_history.main()
+    assert db.get_history("show") == ["a", "b", "c"]
+

--- a/tools/migrate_history.py
+++ b/tools/migrate_history.py
@@ -1,0 +1,49 @@
+"""Convert legacy JSON playback history to the SQLite database."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure the one_tap package is importable when running from the repo root
+repo_root = Path(__file__).resolve().parents[1]
+sys.path.append(str(repo_root / "addons" / "script.module.one_tap" / "lib"))
+
+from one_tap import config, db  # noqa: E402
+
+OLD_JSON_PATH = "special://profile/addon_data/plugin.one_tap.play/progress.json"
+
+
+def main() -> None:
+    src = config._resolve(OLD_JSON_PATH)
+    if not src.exists():
+        print(f"No legacy history found at {src}")
+        return
+
+    with src.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    with db._connect() as conn:
+        for show_id, episodes in data.items():
+            conn.executemany(
+                "INSERT INTO history(show_id, episode) VALUES (?, ?)",
+                ((show_id, ep) for ep in episodes),
+            )
+            conn.execute(
+                """
+                DELETE FROM history
+                WHERE show_id=?
+                  AND rowid NOT IN (
+                    SELECT rowid FROM history WHERE show_id=? ORDER BY rowid DESC LIMIT ?
+                  )
+                """,
+                (show_id, show_id, len(episodes)),
+            )
+
+    dest = config._resolve(db.DB_PATH)
+    print(f"Migrated history from {src} to {dest}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- replace JSON-based playback history with SQLite-backed storage
- add utility to migrate existing JSON history to the new database
- document move to SQLite in implementation notes
- index playback history for faster lookup and bulk migration
- add tests covering history pruning and migration

## Testing
- `python -m py_compile addons/script.module.one_tap/lib/one_tap/db.py tools/migrate_history.py tests/test_db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6c645a808323baa676608b4a1f2f