### PR TITLE
feat: expand caregiver configuration

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -26,6 +26,8 @@ MVP as described in the repository `README`.
 - Caregiver script verifies PINs before launching the menu.
 - Randomizer service chooses the next show using comfort weights and avoids
   repeating the same show consecutively.
+- Caregiver menu now lets tiles be reordered or edited and exposes additional
+  playback settings like excluding recent episodes from random mode.
   
 ## Design Choices
 
@@ -38,6 +40,5 @@ MVP as described in the repository `README`.
 
 ## Next Steps
 
-- Allow caregivers to reorder tiles and edit metadata.
-- Expose further playback settings through the caregiver UI.
+- Build a full graphical caregiver menu experience.
 

--- a/tests/test_caregiver.py
+++ b/tests/test_caregiver.py
@@ -41,7 +41,7 @@ def test_configure_updates_weights(monkeypatch):
         ],
     }
 
-    inputs = iter(["n", "random", "y", "1.5", "2.0", ""])
+    inputs = iter(["n", "random", "5", "y", "1.5", "2.0", ""])
 
     def fake_input(_prompt: str) -> str:
         return next(inputs)
@@ -59,6 +59,7 @@ def test_configure_updates_weights(monkeypatch):
 
     assert saved["mode"] == "random"
     assert saved["random"]["use_comfort_weights"] is True
+    assert saved["random"]["exclude_last_n"] == 5
     assert [t["weight"] for t in saved["tiles"]] == [1.5, 2.0]
 
 
@@ -77,6 +78,7 @@ def test_configure_manages_tiles_and_history(monkeypatch):
         "add",
         "s2",
         "p2",
+        "",  # label
         "",  # default weight
         "remove",
         "s1",
@@ -102,3 +104,51 @@ def test_configure_manages_tiles_and_history(monkeypatch):
     assert [t["show_id"] for t in saved["tiles"]] == ["s2"]
     assert saved["tiles"][0]["path"] == "p2"
     assert saved["history"]["max"] == 75
+
+
+def test_manage_tiles_edit_and_reorder(monkeypatch):
+    import default as caregiver
+
+    cfg = {
+        "mode": "order",
+        "random": {},
+        "tiles": [
+            {"show_id": "s1", "path": "p1", "label": "L1"},
+            {"show_id": "s2", "path": "p2", "label": "L2"},
+        ],
+        "history": {"max": 50},
+    }
+
+    inputs = iter([
+        "y",  # manage tiles
+        "edit",
+        "s1",
+        "NL1",  # new label
+        "p1n",  # new path
+        "",  # weight unchanged
+        "reorder",
+        "s2",
+        "0",
+        "done",
+        "",  # mode unchanged
+        "",  # history unchanged
+    ])
+
+    def fake_input(_prompt: str) -> str:
+        return next(inputs)
+
+    saved: dict = {}
+
+    monkeypatch.setattr(caregiver.config, "load_config", lambda: cfg)
+
+    def fake_save(updated: dict) -> None:
+        saved.update(updated)
+
+    monkeypatch.setattr(caregiver.config, "save_config", fake_save)
+
+    caregiver.configure(fake_input)
+
+    assert [t["show_id"] for t in saved["tiles"]] == ["s2", "s1"]
+    s1 = next(t for t in saved["tiles"] if t["show_id"] == "s1")
+    assert s1["path"] == "p1n"
+    assert s1["label"] == "NL1"


### PR DESCRIPTION
## Summary
- allow caregiver tiles to be reordered and edited
- expose extra playback settings like random episode exclusion
- document updated caregiver capabilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be8d72f644832382d69cce2ddb3d32