### PR TITLE
Add basic caregiver menu with configuration and history purge

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -28,6 +28,8 @@ MVP as described in the repository `README`.
   repeating the same show consecutively.
 - Caregiver menu now lets tiles be reordered or edited and exposes additional
   playback settings like excluding recent episodes from random mode.
+- Added a minimal graphical caregiver menu allowing configuration and playback
+  history purging via Kodi dialogs or a CLI fallback.
   
 ## Design Choices
 
@@ -40,5 +42,6 @@ MVP as described in the repository `README`.
 
 ## Next Steps
 
-- Build a full graphical caregiver menu experience.
+- Polish the caregiver menu interface and expand available maintenance
+  actions.
 

--- a/tests/test_caregiver.py
+++ b/tests/test_caregiver.py
@@ -152,3 +152,25 @@ def test_manage_tiles_edit_and_reorder(monkeypatch):
     s1 = next(t for t in saved["tiles"] if t["show_id"] == "s1")
     assert s1["path"] == "p1n"
     assert s1["label"] == "NL1"
+
+
+def test_menu_runs_selected_actions(monkeypatch):
+    import default as caregiver
+
+    called: list[str] = []
+
+    monkeypatch.setattr(
+        caregiver, "configure", lambda _inp=None: called.append("config")
+    )
+    monkeypatch.setattr(
+        caregiver.db, "purge_history", lambda _show=None: called.append("purge")
+    )
+
+    inputs = iter(["1", "2", "", "3"])
+
+    def fake_input(_prompt: str) -> str:
+        return next(inputs)
+
+    caregiver.menu(fake_input)
+
+    assert called == ["config", "purge"]


### PR DESCRIPTION
## Summary
- add dialog-driven caregiver menu with CLI fallback
- enable playback history purge and configuration from menu
- document new caregiver menu and next steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be8e5d05508323af708877adbc61d7