### PR TITLE
feat(caregiver): add config import/export options

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -28,6 +28,8 @@ MVP as described in the repository `README`.
   repeating the same show consecutively.
 - Caregiver menu now lets tiles be reordered or edited and exposes additional
   playback settings like excluding recent episodes from random mode.
+- Added maintenance helpers to export and import configuration files, exposing
+  them through the caregiver menu.
 - Added a minimal graphical caregiver menu allowing configuration and playback
   history purging via Kodi dialogs or a CLI fallback.
   

--- a/tests/test_caregiver.py
+++ b/tests/test_caregiver.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 
@@ -165,12 +166,56 @@ def test_menu_runs_selected_actions(monkeypatch):
     monkeypatch.setattr(
         caregiver.db, "purge_history", lambda _show=None: called.append("purge")
     )
+    monkeypatch.setattr(
+        caregiver,
+        "export_config",
+        lambda path: called.append(f"export:{path}") or True,
+    )
+    monkeypatch.setattr(
+        caregiver,
+        "import_config",
+        lambda path: called.append(f"import:{path}") or True,
+    )
 
-    inputs = iter(["1", "2", "", "3"])
+    inputs = iter([
+        "1",
+        "2",
+        "",
+        "3",
+        "out.json",
+        "4",
+        "out.json",
+        "5",
+    ])
 
     def fake_input(_prompt: str) -> str:
         return next(inputs)
 
     caregiver.menu(fake_input)
 
-    assert called == ["config", "purge"]
+    assert called == ["config", "purge", "export:out.json", "import:out.json"]
+
+
+def test_export_config_writes_file(tmp_path, monkeypatch):
+    import default as caregiver
+
+    cfg = {"mode": "order", "tiles": []}
+    monkeypatch.setattr(caregiver.config, "load_config", lambda: cfg)
+
+    dest = tmp_path / "cfg.json"
+    assert caregiver.export_config(str(dest)) is True
+    assert json.loads(dest.read_text()) == cfg
+
+
+def test_import_config_reads_file(tmp_path, monkeypatch):
+    import default as caregiver
+
+    src = tmp_path / "cfg.json"
+    data = {"mode": "random"}
+    src.write_text(json.dumps(data))
+
+    saved: dict = {}
+    monkeypatch.setattr(caregiver.config, "save_config", lambda c: saved.update(c))
+
+    assert caregiver.import_config(str(src)) is True
+    assert saved == data


### PR DESCRIPTION
## Summary
- allow exporting current caregiver configuration to an arbitrary file path
- allow importing configuration from JSON and wire both actions into caregiver menu
- signal success or failure from export helper and cover both helpers with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be91ef3f208323827669e8b1b0a4f5